### PR TITLE
When sending out a heartbeat, also send a ping frame

### DIFF
--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -58,6 +58,10 @@ websocket_handle(
         ok -> {[], S};
         shutdown -> {stop, S}
     end;
+
+websocket_handle({pong, _Reply}, S) ->
+    {[], S};
+
 websocket_handle(_Unknown, S) ->
     {stop, S}.
 
@@ -68,6 +72,9 @@ websocket_info(
     case sockjs_ws_handler:reply(RawWebsocket, SessionPid) of
         wait ->
             {[], S};
+        {ok, <<"h">> = Data} ->
+            self() ! go,
+            {reply, [{text, Data}, {ping, Data}], S};
         {ok, Data} ->
             self() ! go,
             {reply, {text, Data}, S};


### PR DESCRIPTION
My current implementation of the client can be quiet for hours, which would
trigger the 60-second timeout in `cowboy_websocket`. Adding a ping-frame
forces clients to respond with a pong-frame, restarting the loop. In testing
I found that some browsers work better with some payload data added, so I'm
adding the same "h" string as payload.

I figured I'd send a PR here since Ably seems to be maintaining the most 
up-to-date & worked on fork.

I'm quite new to erlang development so any pointers on how to improve the
implementation are welcome. I'm not very proud of how I forced it in there,
and feel like it would be better to put this in `sockjs_ws_handler` instead,
but that felt like a bigger refactor.